### PR TITLE
implement JIRA pat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <jira-rest-java-atlassian.version>5.2.1</jira-rest-java-atlassian.version>
+        <jira-rest-java-atlassian.version>5.2.4</jira-rest-java-atlassian.version>
         <fugue.version>4.7.2</fugue.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <kohsuke.version>1.116</kohsuke.version>

--- a/src/main/java/dev/snowdrop/release/App.java
+++ b/src/main/java/dev/snowdrop/release/App.java
@@ -56,15 +56,21 @@ public class App implements QuarkusApplication {
     @CommandLine.Option(
         names = {"-u", "--user"},
         description = "JIRA user",
-        required = true,
+        required = false,
         scope = CommandLine.ScopeType.INHERIT)
     private String user;
     @CommandLine.Option(
         names = {"-p", "--password"},
         description = "JIRA password",
-        required = true,
+        required = false,
         scope = CommandLine.ScopeType.INHERIT)
     private String password;
+    @CommandLine.Option(
+        names = {"-t", "--token"},
+        description = "JIRA Personal Access Token",
+        required = true,
+        scope = CommandLine.ScopeType.INHERIT)
+    private String pat;
     @CommandLine.Option(
         names = "--url",
         description = "URL of the JIRA server",

--- a/src/main/java/dev/snowdrop/release/services/IssueService.java
+++ b/src/main/java/dev/snowdrop/release/services/IssueService.java
@@ -17,6 +17,7 @@ import com.atlassian.jira.rest.client.api.domain.input.ComplexIssueInputFieldVal
 import com.atlassian.jira.rest.client.api.domain.input.IssueInput;
 import com.atlassian.jira.rest.client.api.domain.input.IssueInputBuilder;
 import com.atlassian.jira.rest.client.api.domain.input.LinkIssuesInput;
+import com.atlassian.jira.rest.client.api.domain.input.TransitionInput;
 import dev.snowdrop.release.model.Component;
 import dev.snowdrop.release.model.IssueSource;
 import dev.snowdrop.release.model.Release;
@@ -179,6 +180,13 @@ public class IssueService {
         }
         LOG.infof("Issue %s doesn't exists for %s component, skipping it", getURLFor(key), source.getName());
         return null;
+    }
+
+    public void changeIssueState(String issueKey, int action) {
+        final IssueRestClient cl = restClient.getIssueClient();
+        Issue issue = cl.getIssue(issueKey).claim();
+        TransitionInput transitionInput = new TransitionInput(action);
+        cl.transition(issue, transitionInput);
     }
 
     private static IssueInput getIssueInput(IssueSource source) {

--- a/src/main/java/dev/snowdrop/release/services/JiraBearerHttpAuthenticationHandler.java
+++ b/src/main/java/dev/snowdrop/release/services/JiraBearerHttpAuthenticationHandler.java
@@ -1,0 +1,19 @@
+package dev.snowdrop.release.services;
+
+import com.atlassian.httpclient.api.Request;
+import com.atlassian.jira.rest.client.api.AuthenticationHandler;
+
+public class JiraBearerHttpAuthenticationHandler implements AuthenticationHandler {
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private final String token;
+
+    public JiraBearerHttpAuthenticationHandler(final String token) {
+        this.token = token;
+    }
+
+
+    @Override
+    public void configure(Request.Builder builder) {
+        builder.setHeader(AUTHORIZATION_HEADER, "Bearer " + token);
+    }
+}

--- a/src/test/java/dev/snowdrop/release/services/IssueServiceTest.java
+++ b/src/test/java/dev/snowdrop/release/services/IssueServiceTest.java
@@ -13,9 +13,7 @@
  */
 package dev.snowdrop.release.services;
 
-import com.atlassian.jira.rest.client.api.JiraRestClient;
 import com.atlassian.jira.rest.client.api.domain.BasicIssue;
-import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import dev.snowdrop.release.model.Issue;
 import dev.snowdrop.release.model.POM;
@@ -26,10 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
 import java.io.InputStream;
-import java.net.URI;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -59,9 +57,11 @@ public class IssueServiceTest {
         assertTrue(issueKey != null && issueKey.getKey() != null && issueKey.getKey().length() > 0, issueKey.getKey());
         try {
             service.deleteIssues(List.of(issueKey.getKey()));
-            assertTrue(true);
+            assertFalse(true);
         } catch (Throwable e) {
-            assertTrue(false, e.getMessage());
+            assertFalse(false, e.getMessage());
+            assertTrue(e.getMessage().contains("You do not have permission to delete issues in this project."));
+            service.changeIssueState(issueKey.getKey(), 2);
         }
     }
 

--- a/src/test/java/dev/snowdrop/release/services/JiraClientConfigurationProperties.java
+++ b/src/test/java/dev/snowdrop/release/services/JiraClientConfigurationProperties.java
@@ -11,6 +11,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package dev.snowdrop.release.services;
 
 import com.atlassian.jira.rest.client.api.JiraRestClient;
@@ -33,9 +34,17 @@ public class JiraClientConfigurationProperties {
     @Produces
     @ApplicationScoped
     public JiraRestClient client() {
-        final String user = ConfigProvider.getConfig().getValue("jboss.jira.user", String.class);
-        final String password = ConfigProvider.getConfig().getValue("jboss.jira.password", String.class);
         AsynchronousJiraRestClientFactory factory = new AsynchronousJiraRestClientFactory();
-        return factory.createWithBasicHttpAuthentication(URI.create(Utility.JIRA_SERVER), user, password);
+        JiraRestClient jiraRestClient;
+        final String pat = ConfigProvider.getConfig().getValue("jboss.jira.pat", String.class);
+        if (pat != null) {
+            JiraBearerHttpAuthenticationHandler handler = new JiraBearerHttpAuthenticationHandler(pat);
+            jiraRestClient = factory.createWithAuthenticationHandler(URI.create(Utility.JIRA_SERVER), handler);
+        } else {
+            final String user = ConfigProvider.getConfig().getValue("jboss.jira.user", String.class);
+            final String password = ConfigProvider.getConfig().getValue("jboss.jira.password", String.class);
+            jiraRestClient = factory.createWithBasicHttpAuthentication(URI.create(Utility.JIRA_SERVER), user, password);
+        }
+        return jiraRestClient;
     }
 }


### PR DESCRIPTION
Implemented access to JIRA using a Personal Access Token  as was the only way to be able to interact with the JIRA REST API.

NOTE: JIRA PAT is of mandatory use. For now I made the user and password optional but probably these could be removed.

NOTE 2: Deleting a Jira issue is no longer allowed so I updated the test to CLOSE the test issues.